### PR TITLE
Unify line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf
+
+*.gd text
+*.tscn text
+
+*.icns binary
+*.ico binary
+*.png binary


### PR DESCRIPTION
Our .gitattributes file was leaving Windows platforms able to commit CRLF line endings where they should be committing LF endings. Updated this attribute to rectify this issue.