### PR TITLE
Bugfix - Multiple Units taking turns on a GameTick was inconsistent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf
+
+*.gd text
+*.tscn text
+
+*.icns binary
+*.ico binary
+*.png binary

--- a/src/scripts/ColiseumGametickSystem.gd
+++ b/src/scripts/ColiseumGametickSystem.gd
@@ -54,12 +54,22 @@ func _gametick_loop():
 		emit_signal("started_action_phase")
 		
 		# Dummy logic just to see processing Unit.
-		# This logic should be moved out of GameTick and into Units
-		for unit in self.units_node.readied_units:
-			var unit_stats = unit.get_node("UnitStatComponent")
+		# This logic should be moved out of GameTick
+		# and into the manager for Units
+		for unit in self.units_node.units:
+			print(unit.get_tick_counter())
+		
+		while not self.units_node.readied_units.empty():
+			var unit = self.units_node.readied_units.pop_front()
 			print(unit.name + "'s Turn!")
 			unit.take_turn()
 			yield(unit, "completed_turn")
+			pass
+		
+#		for unit in self.units_node.readied_units:
+#			print(unit.name + "'s Turn!")
+#			unit.take_turn()
+#			yield(unit, "completed_turn")
 		
 		emit_signal("finished_action_phase")
 		

--- a/src/scripts/ColiseumGametickSystem.gd
+++ b/src/scripts/ColiseumGametickSystem.gd
@@ -30,6 +30,7 @@ func _ready():
 		self.connect("started_gt_phase", unit, "progress_tick_counter")
 		unit.connect("completed_turn", units_node, "unready_unit")
 		unit.connect("unit_ready", units_node, "ready_unit")
+	self.connect("finished_gt_phase", units_node, "sort_unit_queue")
 
 
 func _gametick_loop():

--- a/src/scripts/UnitComponent.gd
+++ b/src/scripts/UnitComponent.gd
@@ -22,8 +22,12 @@ func take_turn():
 
 func progress_tick_counter(gametick_counter):
 	self.unit_stats.tick_counter += self.unit_stats.stat_speed
-	if self.unit_stats.tick_counter > 100:
+	if self.unit_stats.tick_counter >= 100:
 		emit_signal("unit_ready", self)
+
+
+func get_tick_counter():
+	return unit_stats.tick_counter
 
 
 #func _unit_update_loop():

--- a/src/scripts/UnitsComponent.gd
+++ b/src/scripts/UnitsComponent.gd
@@ -11,7 +11,6 @@ func _ready():
 
 func ready_unit(unit):
 	self.readied_units.append(unit)
-	self.readied_units.sort_custom(self, "sort_unit_queue")
 
 
 func unready_unit(unit):

--- a/src/scripts/UnitsComponent.gd
+++ b/src/scripts/UnitsComponent.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 onready var units = self.get_children()
-var readied_units = []
+var readied_units = [] # Queue of readied Units
 
 
 # Called when the node enters the scene tree for the first time.
@@ -11,7 +11,18 @@ func _ready():
 
 func ready_unit(unit):
 	self.readied_units.append(unit)
+	self.readied_units.sort_custom(self, "sort_unit_queue")
 
 
 func unready_unit(unit):
-	self.readied_units.erase(unit)
+	#self.readied_units.erase(unit)
+	pass
+
+
+func sort_unit_queue(unit_1, unit_2):
+	var unit_1_tick = unit_1.get_tick_counter()
+	var unit_2_tick = unit_2.get_tick_counter()
+	if unit_2_tick < unit_1_tick:
+		return true
+	else:
+		return false


### PR DESCRIPTION
Dependent on #6 being merged for line endings

Bug: The test code for Units taking turns was removing Units from a list being iterated over, making it where some Units were not being processed until the subsequent GameTick.

Resolution: Changed the `readied_units` list to act more like a queue. At the end of the gt+ phase, the queue is sorted such that Units with a higher tick_counter act first (as feels reasonable, but we could certainly change this so enemies/allies always act first in these cases as well). During the action phase, the `readied_units` list has its first element popped and takes its turn, going through the contents until the list is empty. This also means units that ready themselves to take another turn can take their action that same gametick, instead of an alternative solution of copying the readied units list to iterate over. 